### PR TITLE
feat: add aws and ecr wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ This orb can be used to retrieve credentials from Vault.
 ### Supported Login Methods:
 
 * AppRole
+
+**Note:** You cannot have AWS_ACCESS_KEY_ID and AWS_SECRET_KEY_ID variables set in the project's environment variables since this conflicts with the Orb generating its own credentials.
+
+## Environment variables
+
+These are the environment variables that need to be set within your project:
+
+| Name | Description | Value |
+|------|-------------|-------|
+| VAULT_ADDR | The address for the vault service | https://vault.homexlabs.com |
+| VAULT_ROLE_ID | This specifies the AppRole ID to authenticate to vault | |
+| VAULT_SECRET_ID | This is the Secret ID for the AppRole ID | |

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -4,4 +4,6 @@ description: >
   Easily integrate Vault Credentials into your CircleCI projects.
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.16
+  aws-cli: circleci/aws-cli@0.1.20
+  aws-ecr: circleci/aws-ecr@6.7.0
+  aws-s3: circleci/aws-s3@1.0.15

--- a/src/commands/aws-login.yml
+++ b/src/commands/aws-login.yml
@@ -68,4 +68,4 @@ steps:
       aws-role-session-name: << parameters.aws-role-session-name >>
       aws-source-profile-name: << parameters.aws-profile-name >>
       aws-profile-name: "<< parameters.aws-profile-name>>-assume"
-      set-default-profile: << parameters.set-default-region >>
+      set-default-profile: << parameters.set-default-profile >>

--- a/src/commands/aws-login.yml
+++ b/src/commands/aws-login.yml
@@ -62,7 +62,7 @@ steps:
       aws-region: << parameters.aws-region >>
       vault-addr: << parameters.vault-addr >>
       vault-path: << parameters.vault-path >>
-      configure-default-region: << parameters.configure-default-region
+      configure-default-region: << parameters.configure-default-region >>
   - assume-aws-role:
       aws-role-arn: << parameters.assume-aws-role >>
       aws-role-session-name: << parameters.aws-role-session-name >>

--- a/src/commands/aws-login.yml
+++ b/src/commands/aws-login.yml
@@ -64,7 +64,7 @@ steps:
       vault-path: << parameters.vault-path >>
       configure-default-region: << parameters.configure-default-region >>
   - assume-aws-role:
-      aws-role-arn: << parameters.assume-aws-role >>
+      aws-role-arn: << parameters.aws-role-arn >>
       aws-role-session-name: << parameters.aws-role-session-name >>
       aws-source-profile-name: << parameters.aws-profile-name >>
       aws-profile-name: "<< parameters.aws-profile-name>>-assume"

--- a/src/commands/aws-login.yml
+++ b/src/commands/aws-login.yml
@@ -1,0 +1,71 @@
+description: >
+  This is a wrapper to simplify the login to vault, retrieves the AWS credentials, validates them and assumes an AWS role.
+
+parameters:
+  aws-profile-name:
+    description: Profile name to be configured.
+    type: string
+    default: default
+  aws-region:
+    description: |
+      Env var of AWS region to operate in
+      (defaults to AWS_DEFAULT_REGION)
+    type: env_var_name
+    default: AWS_DEFAULT_REGION
+  aws-role-arn:
+    description: Role ARN to be assumed
+    type: string
+  aws-role-session-name:
+    description: Role session name
+    type: string
+    default: CircleCI
+  configure-default-region:
+    description: >
+      Some AWS actions don't require a region; set this to false if you do not
+      want to store a default region in ~/.aws/config
+    type: boolean
+    default: true
+  set-default-profile:
+    description: >
+      Do you want to set this assume role profile as the default going forward.
+    type: boolean
+    default: true
+  vault-addr:
+    type: string
+    description: Override VAULT_ADDR coming from context.
+    default: $VAULT_ADDR
+  vault-path:
+    type: string
+    description: The vault path to the AWS Role.
+  vault-role-id:
+    type: env_var_name
+    description: Vault AppRole ID
+    default: VAULT_ROLE_ID
+  vault-secret-id:
+    type: env_var_name
+    description: Vault AppRole Secret ID
+    default: VAULT_SECRET_ID
+  vault-version:
+    type: string
+    description: Install a specific version of vault.
+    default: latest
+
+steps:
+  - install:
+      vault-version: << parameters.vault-version >>
+  - login:
+      vault-addr: << parameters.vault-addr >>
+      vault-role-id: << parameters.vault-role-id >>
+      vault-secret-id: << parameters.vault-secret-id >>
+  - get-aws-creds:
+      aws-profile-name: << parameters.aws-profile-name >>
+      aws-region: << parameters.aws-region >>
+      vault-addr: << parameters.vault-addr >>
+      vault-path: << parameters.vault-path >>
+      configure-default-region: << parameters.configure-default-region
+  - assume-aws-role:
+      aws-role-arn: << parameters.assume-aws-role >>
+      aws-role-session-name: << parameters.aws-role-session-name >>
+      aws-source-profile-name: << parameters.aws-profile-name >>
+      aws-profile-name: "<< parameters.aws-profile-name>>-assume"
+      set-default-profile: << parameters.set-default-region >>

--- a/src/commands/ecr-build-and-push-image.yml
+++ b/src/commands/ecr-build-and-push-image.yml
@@ -35,6 +35,10 @@ parameters:
       Extra flags to pass to docker build. For examples, see https://docs.docker.com/engine/reference/commandline/build
     type: string
     default: ""
+  no-output-timeout:
+    description: The amount of time to allow the docker command to run before timing out.
+    type: string
+    default: 10m
   path:
     description: Path to the directory containing your Dockerfile and build context.
       Defaults to . (working directory).
@@ -43,7 +47,6 @@ parameters:
   repo:
     description: Name of an Amazon ECR repository
     type: string
-
   set-default-profile:
     description: >
       Do you want to set this assume role profile as the default going forward.
@@ -78,10 +81,10 @@ steps:
   - ecr-login:
       aws-profile-name: << parameters.aws-profile-name >>
       aws-region: << parameters.aws-region >>
-      aws-role-arn: << parameters.assume-aws-role >>
+      aws-role-arn: << parameters.aws-role-arn >>
       aws-role-session-name: << parameters.aws-role-session-name >>
       configure-default-region: << parameters.configure-default-region >>
-      set-default-profile: << parameters.set-default-region >>
+      set-default-profile: << parameters.set-default-profile >>
       vault-addr: << parameters.vault-addr >>
       vault-path: << parameters.vault-path >>
       vault-role-id: << parameters.vault-role-id >>

--- a/src/commands/ecr-build-and-push-image.yml
+++ b/src/commands/ecr-build-and-push-image.yml
@@ -1,0 +1,98 @@
+description: >
+  This is a wrapper to simplify the building and pushing images to ECR. This only supports building and pushing a single image. If you are building multiple images it is better to use the `ecr-login` command and then build/push the images manually.
+
+parameters:
+  aws-profile-name:
+    description: Profile name to be configured.
+    type: string
+    default: default
+  aws-region:
+    description: |
+      Env var of AWS region to operate in
+      (defaults to AWS_DEFAULT_REGION)
+    type: env_var_name
+    default: AWS_DEFAULT_REGION
+  aws-role-arn:
+    description: Role ARN to be assumed
+    type: string
+  aws-role-session-name:
+    description: Role session name
+    type: string
+    default: CircleCI
+  configure-default-region:
+    description: >
+      Some AWS actions don't require a region; set this to false if you do not
+      want to store a default region in ~/.aws/config
+    type: boolean
+    default: true
+  dockerfile:
+    description: Name of dockerfile to use. Defaults to Dockerfile.
+    type: string
+    default: Dockerfile
+  extra-build-args:
+    description: |
+      Extra flags to pass to docker build. For examples, see https://docs.docker.com/engine/reference/commandline/build
+    type: string
+    default: ""
+  path:
+    description: Path to the directory containing your Dockerfile and build context.
+      Defaults to . (working directory).
+    type: string
+    default: .
+  repo:
+    description: Name of an Amazon ECR repository
+    type: string
+
+  set-default-profile:
+    description: >
+      Do you want to set this assume role profile as the default going forward.
+    type: boolean
+    default: true
+  tag:
+    description: A comma-separated string containing docker image tags (default
+      = latest)
+    type: string
+    default: latest
+  vault-addr:
+    type: string
+    description: Override VAULT_ADDR coming from context.
+    default: $VAULT_ADDR
+  vault-path:
+    type: string
+    description: The vault path to the AWS Role.
+  vault-role-id:
+    type: env_var_name
+    description: Vault AppRole ID
+    default: VAULT_ROLE_ID
+  vault-secret-id:
+    type: env_var_name
+    description: Vault AppRole Secret ID
+    default: VAULT_SECRET_ID
+  vault-version:
+    type: string
+    description: Install a specific version of vault.
+    default: latest
+
+steps:
+  - ecr-login:
+      aws-profile-name: << parameters.aws-profile-name >>
+      aws-region: << parameters.aws-region >>
+      aws-role-arn: << parameters.assume-aws-role >>
+      aws-role-session-name: << parameters.aws-role-session-name >>
+      configure-default-region: << parameters.configure-default-region
+      set-default-profile: << parameters.set-default-region >>
+      vault-addr: << parameters.vault-addr >>
+      vault-path: << parameters.vault-path >>
+      vault-role-id: << parameters.vault-role-id >>
+      vault-secret-id: << parameters.vault-secret-id >>
+      vault-version: << parameters.vault-version >>
+  - aws-ecr/build-image:
+      dockerfile: <<parameters.dockerfile>>
+      extra-build-args: <<parameters.extra-build-args>>
+      no-output-timeout: <<parameters.no-output-timeout>>
+      path: <<parameters.path>>
+      repo: <<parameters.repo>>
+      tag: <<parameters.tag>>
+  - aws-ecr/push-image:
+      repo: <<parameters.repo>>
+      tag: <<parameters.tag>>

--- a/src/commands/ecr-build-and-push-image.yml
+++ b/src/commands/ecr-build-and-push-image.yml
@@ -1,5 +1,6 @@
 description: >
-  This is a wrapper to simplify the building and pushing images to ECR. This only supports building and pushing a single image. If you are building multiple images it is better to use the `ecr-login` command and then build/push the images manually.
+  This is a wrapper to simplify the building and pushing images to ECR. This only supports building and pushing a single image.
+  If you are building multiple images it is better to use the `ecr-login` command and then build/push the images manually.
 
 parameters:
   aws-profile-name:

--- a/src/commands/ecr-build-and-push-image.yml
+++ b/src/commands/ecr-build-and-push-image.yml
@@ -80,7 +80,7 @@ steps:
       aws-region: << parameters.aws-region >>
       aws-role-arn: << parameters.assume-aws-role >>
       aws-role-session-name: << parameters.aws-role-session-name >>
-      configure-default-region: << parameters.configure-default-region
+      configure-default-region: << parameters.configure-default-region >>
       set-default-profile: << parameters.set-default-region >>
       vault-addr: << parameters.vault-addr >>
       vault-path: << parameters.vault-path >>

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -56,7 +56,7 @@ steps:
       aws-region: << parameters.aws-region >>
       aws-role-arn: << parameters.assume-aws-role >>
       aws-role-session-name: << parameters.aws-role-session-name >>
-      configure-default-region: << parameters.configure-default-region
+      configure-default-region: << parameters.configure-default-region >>
       set-default-profile: << parameters.set-default-region >>
       vault-addr: << parameters.vault-addr >>
       vault-path: << parameters.vault-path >>

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -54,10 +54,10 @@ steps:
   - aws-login:
       aws-profile-name: << parameters.aws-profile-name >>
       aws-region: << parameters.aws-region >>
-      aws-role-arn: << parameters.assume-aws-role >>
+      aws-role-arn: << parameters.aws-role-arn >>
       aws-role-session-name: << parameters.aws-role-session-name >>
       configure-default-region: << parameters.configure-default-region >>
-      set-default-profile: << parameters.set-default-region >>
+      set-default-profile: << parameters.set-default-profile >>
       vault-addr: << parameters.vault-addr >>
       vault-path: << parameters.vault-path >>
       vault-role-id: << parameters.vault-role-id >>

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -1,0 +1,66 @@
+description: >
+  This is a wrapper to simplify the login to ECR. This completes the login to vault, the setup of AWS credentials and the login to ECR.
+
+parameters:
+  aws-profile-name:
+    description: Profile name to be configured.
+    type: string
+    default: default
+  aws-region:
+    description: |
+      Env var of AWS region to operate in
+      (defaults to AWS_DEFAULT_REGION)
+    type: env_var_name
+    default: AWS_DEFAULT_REGION
+  aws-role-arn:
+    description: Role ARN to be assumed
+    type: string
+  aws-role-session-name:
+    description: Role session name
+    type: string
+    default: CircleCI
+  configure-default-region:
+    description: >
+      Some AWS actions don't require a region; set this to false if you do not
+      want to store a default region in ~/.aws/config
+    type: boolean
+    default: true
+  set-default-profile:
+    description: >
+      Do you want to set this assume role profile as the default going forward.
+    type: boolean
+    default: true
+  vault-addr:
+    type: string
+    description: Override VAULT_ADDR coming from context.
+    default: $VAULT_ADDR
+  vault-path:
+    type: string
+    description: The vault path to the AWS Role.
+  vault-role-id:
+    type: env_var_name
+    description: Vault AppRole ID
+    default: VAULT_ROLE_ID
+  vault-secret-id:
+    type: env_var_name
+    description: Vault AppRole Secret ID
+    default: VAULT_SECRET_ID
+  vault-version:
+    type: string
+    description: Install a specific version of vault.
+    default: latest
+
+steps:
+  - aws-login:
+      aws-profile-name: << parameters.aws-profile-name >>
+      aws-region: << parameters.aws-region >>
+      aws-role-arn: << parameters.assume-aws-role >>
+      aws-role-session-name: << parameters.aws-role-session-name >>
+      configure-default-region: << parameters.configure-default-region
+      set-default-profile: << parameters.set-default-region >>
+      vault-addr: << parameters.vault-addr >>
+      vault-path: << parameters.vault-path >>
+      vault-role-id: << parameters.vault-role-id >>
+      vault-secret-id: << parameters.vault-secret-id >>
+      vault-version: << parameters.vault-version >>
+  - aws-ecr/ecr-login

--- a/src/commands/get-aws-creds.yml
+++ b/src/commands/get-aws-creds.yml
@@ -1,4 +1,4 @@
-description: Retrieves AWS credentials and sets them as an AWS profile
+description: Retrieves AWS credentials and sets them as an AWS profile.
 
 parameters:
   aws-profile-name:
@@ -24,7 +24,7 @@ parameters:
   vault-path:
     type: string
     description: The vault path to the AWS Role.
-    
+
 steps:
   - aws-cli/install
   - run:

--- a/src/commands/get-aws-creds.yml
+++ b/src/commands/get-aws-creds.yml
@@ -1,13 +1,6 @@
 description: Retrieves AWS credentials and sets them as an AWS profile
 
 parameters:
-  vault-addr:
-    type: string
-    description: Override VAULT_ADDR coming from context.
-    default: $VAULT_ADDR
-  vault-path:
-    type: string
-    description: The vault path to the AWS Role.
   aws-profile-name:
     description: Profile name to be configured.
     type: string
@@ -24,7 +17,14 @@ parameters:
       want to store a default region in ~/.aws/config
     type: boolean
     default: true
-
+  vault-addr:
+    type: string
+    description: Override VAULT_ADDR coming from context.
+    default: $VAULT_ADDR
+  vault-path:
+    type: string
+    description: The vault path to the AWS Role.
+    
 steps:
   - aws-cli/install
   - run:


### PR DESCRIPTION
Adds a couple of wrapper functions:

1. aws-login, which wraps all of the vault login/aws credential setup in one command
2. ecr-login, same as above but adds the ecr-login command
3. ecr-build-and-push, same as above but adds building and pushing an image to ECR