### PR TITLE
feat: make the aws role arn optional

### DIFF
--- a/src/commands/aws-login.yml
+++ b/src/commands/aws-login.yml
@@ -24,6 +24,7 @@ parameters:
   aws-role-arn:
     description: Role ARN to be assumed
     type: string
+    default: ""
   aws-role-session-name:
     description: Role session name
     type: string
@@ -72,10 +73,13 @@ steps:
       aws-region: << parameters.aws-region >>
       vault-path: << parameters.vault-path >>
       configure-default-region: << parameters.configure-default-region >>
-  - assume-aws-role:
-      aws-cli-version: << parameters.aws-cli-version >>
-      aws-role-arn: << parameters.aws-role-arn >>
-      aws-role-session-name: << parameters.aws-role-session-name >>
-      aws-source-profile-name: << parameters.aws-profile-name >>
-      aws-profile-name: "<< parameters.aws-profile-name>>-assume"
-      set-default-profile: << parameters.set-default-profile >>
+  - when:
+      condition: << parameters.aws-role-arn >>
+      steps:
+      - assume-aws-role:
+          aws-cli-version: << parameters.aws-cli-version >>
+          aws-role-arn: << parameters.aws-role-arn >>
+          aws-role-session-name: << parameters.aws-role-session-name >>
+          aws-source-profile-name: << parameters.aws-profile-name >>
+          aws-profile-name: "<< parameters.aws-profile-name>>-assume"
+          set-default-profile: << parameters.set-default-profile >>

--- a/src/commands/ecr-build-and-push-image.yml
+++ b/src/commands/ecr-build-and-push-image.yml
@@ -25,6 +25,7 @@ parameters:
   aws-role-arn:
     description: Role ARN to be assumed
     type: string
+    default: ""
   aws-role-session-name:
     description: Role session name
     type: string

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -24,6 +24,7 @@ parameters:
   aws-role-arn:
     description: Role ARN to be assumed
     type: string
+    default: ""
   aws-role-session-name:
     description: Role session name
     type: string

--- a/src/commands/s3-cp.yml
+++ b/src/commands/s3-cp.yml
@@ -30,6 +30,7 @@ parameters:
   aws-role-arn:
     description: Role ARN to be assumed
     type: string
+    default: ""
   aws-role-session-name:
     description: Role session name
     type: string

--- a/src/commands/s3-sync.yml
+++ b/src/commands/s3-sync.yml
@@ -30,6 +30,7 @@ parameters:
   aws-role-arn:
     description: Role ARN to be assumed
     type: string
+    default: ""
   aws-role-session-name:
     description: Role session name
     type: string


### PR DESCRIPTION
<!---
Please review the following Pull Request Checklist http://github.com/HomeXlabs/hx-infrastructure/docs/CHECKLIST_PR.md)
--->

# Description

This allows the AWS ARN to be skipped, allowing the main AWS credentials to be used directly. This is useful for when the application will assume the role or if no role is needed at all.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
