### PR TITLE
Adding GCP authentification

### DIFF
--- a/src/commands/gcp-login.yml
+++ b/src/commands/gcp-login.yml
@@ -1,0 +1,15 @@
+description: >
+  This creates a keypair file to authenticate to GCP
+
+parameters:
+  keypair_filename:
+    description: Filename of the keypair file
+    type: string
+    default: /gcp_credentials.json
+  
+  
+steps:
+  - run:
+      name: Exporting variable to file
+      command: |
+        echo $GCP_KEYFILE" >> << parameters.keypair_filename >>

--- a/src/commands/gcp-login.yml
+++ b/src/commands/gcp-login.yml
@@ -6,10 +6,10 @@ parameters:
     description: Filename of the keypair file
     type: string
     default: /gcp_credentials.json
-  
-  
+
+
 steps:
   - run:
       name: Exporting variable to file
       command: |
-        echo $GCP_KEYFILE" >> << parameters.keypair_filename >>
+        echo $GCP_KEYFILE >> << parameters.keypair_filename >>


### PR DESCRIPTION
<!---
Please review the following Pull Request Checklist http://github.com/HomeXlabs/hx-infrastructure/docs/CHECKLIST_PR.md)
--->

# Description

I am adding a new variable into Vault, and I want CircleCI to access it. The variable contains the content of a keypair file. If you have the file, you can then authenticate to GCP (permissions can be manage with the associated role). This PR add a new command, to create the keypair file from Vault.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
